### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 2.x     | :white_check_mark: |
+| < 2.0   | :x:                |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please report it responsibly.
+
+**Please do NOT open a public GitHub issue for security vulnerabilities.**
+
+Instead, please report them via [GitHub's private vulnerability reporting](https://github.com/tamtamchik/app-store-receipt-parser/security/advisories/new).
+
+You should expect an initial response within 72 hours. Once the issue is confirmed, a fix will be released as soon as possible depending on the complexity of the vulnerability.


### PR DESCRIPTION
## Summary
- Add `SECURITY.md` with supported versions and vulnerability reporting instructions
- Points reporters to GitHub's private vulnerability reporting

## Test plan
- [x] Verify SECURITY.md renders correctly on GitHub
- [x] Verify "Security" tab on repo links to the policy