### PR TITLE
2.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tamtamchik/app-store-receipt-parser",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tamtamchik/app-store-receipt-parser",
-      "version": "2.2.2",
+      "version": "2.2.3",
       "license": "MIT",
       "dependencies": {
         "asn1js": "^3.0.7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tamtamchik/app-store-receipt-parser",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "A lightweight TypeScript library for extracting transaction IDs from Apple's ASN.1 encoded receipts.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## Summary
- Bump version to 2.2.3

## Changelog since 2.2.2
- Upgrade asn1js from 3.0.6 to 3.0.7
- Add security policy
- Migrate from Jest to Node native test runner + c8
- Add GitHub Actions CI (lint, build, test on Node 20/22/24)
- Add Dependabot configuration
- Add .editorconfig, bump Scrutinizer to Node 22
- Consolidate ESLint dependencies (drop 3 packages, fix deprecations)
- Dev deps reduced from 12 to 8, 0 vulnerabilities