### PR TITLE
Conservatively pin Dependabot-managed GitHub Actions and expose in-app receipt data

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,25 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    open-pull-requests-limit: 10
-    groups:
-      dev-dependencies:
-        dependency-type: development
+      day: monday
+      time: "09:00"
+      timezone: Europe/Lisbon
+    open-pull-requests-limit: 2
+    versioning-strategy: lockfile-only
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 14
+      semver-patch-days: 7
 
+  # Workflows pin actions by full commit SHA; Dependabot updates those pins.
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Europe/Lisbon
+    open-pull-requests-limit: 1
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: npm
@@ -26,8 +26,8 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: npm
@@ -41,8 +41,8 @@ jobs:
       matrix:
         node-version: [20, 22, 24]
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm


### PR DESCRIPTION
## Summary
- Tighten Dependabot scheduling and cooldowns for npm and GitHub Actions updates.
- Pin workflow actions to full commit SHAs while keeping Dependabot responsible for updating those pins.
- Parse nested `IN_APP_RECEIPTS` into the receipt model and document the new shape in the README.
- Add tests covering in-app receipt extraction and array consistency.

## Testing
- YAML validation passed for the Dependabot and workflow config.
- Diff formatting checks passed.
- Unit tests were updated to assert `IN_APP_RECEIPTS` parsing behavior.