### PR TITLE
Release 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.3.0
+## 2.3.0 - 2026-05-27
 
 ### Added
 
@@ -16,3 +16,99 @@
 
 - Updated dependency lockfile entries already merged into `main`.
 - Pinned GitHub Actions workflow actions by commit SHA and constrained Dependabot update cadence.
+
+## 2.2.3 - 2026-04-15
+
+### Added
+
+- Added a security policy.
+- Added GitHub Actions CI for linting, building, and testing.
+
+### Changed
+
+- Migrated tests from Jest to the Node.js test runner.
+- Split linting into `lint` and `lint:fix` scripts.
+
+### Fixed
+
+- Upgraded `asn1js` from `3.0.6` to `3.0.7`.
+
+### Maintenance
+
+- Updated development dependencies and GitHub Actions versions.
+- Consolidated ESLint dependencies.
+
+## 2.2.2 - 2025-05-02
+
+### Fixed
+
+- Upgraded `asn1js` from `3.0.5` to `3.0.6`.
+
+### Maintenance
+
+- Updated dependencies.
+
+## 2.2.1 - 2024-09-25
+
+### Fixed
+
+- Fixed exported TypeScript types.
+
+## 2.2.0 - 2024-09-25
+
+### Changed
+
+- Refactored parser and verifier internals into classes.
+- Updated TypeScript and ESLint configuration.
+
+### Maintenance
+
+- Updated dependencies.
+
+## 2.1.2 - 2024-05-20
+
+### Maintenance
+
+- Updated the Scrutinizer Node.js version.
+
+## 2.1.1 - 2024-05-06
+
+### Maintenance
+
+- Updated dependencies.
+
+## 2.1.0 - 2024-04-11
+
+### Added
+
+- Added mapping for the `ENVIRONMENT` receipt field.
+- Added `Production` as the default parsed environment.
+
+### Fixed
+
+- Fixed parsed receipt completeness checks for the `ENVIRONMENT` field.
+
+### Maintenance
+
+- Updated dependencies and documentation.
+
+## 2.0.0 - 2024-01-10
+
+### Changed
+
+- Refactored the parser implementation for the `2.x` release line.
+- Updated documentation and project structure.
+
+## 1.0.1 - 2023-11-14
+
+### Maintenance
+
+- Simplified tests.
+- Moved CI from CircleCI to Scrutinizer.
+
+## 1.0.0 - 2023-08-19
+
+### Added
+
+- Added the initial receipt parsing functionality.
+- Added tests, publishing configuration, and README documentation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Maintenance
 
 - Updated dependency lockfile entries already merged into `main`.
+- Updated transitive development dependency resolution for `brace-expansion` to clear npm audit findings.
 - Pinned GitHub Actions workflow actions by commit SHA and constrained Dependabot update cadence.
 
 ## 2.2.3 - 2026-04-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+## 2.3.0
+
+### Added
+
+- Added `IN_APP_RECEIPTS` to parsed receipts, exposing each supported in-app purchase receipt as a structured object.
+- Exported the `InAppReceipt` type from the package entrypoint.
+
+### Changed
+
+- Updated package metadata and documentation to describe selected receipt field parsing beyond transaction ID extraction.
+- Updated the package version to `2.3.0`.
+
+### Maintenance
+
+- Updated dependency lockfile entries already merged into `main`.
+- Pinned GitHub Actions workflow actions by commit SHA and constrained Dependabot update cadence.

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 [![Software License][ico-license]](./LICENSE)
 [![Total Downloads][ico-downloads]][link-downloads]
 
-A lightweight TypeScript library for extracting transaction IDs from Apple's ASN.1 encoded Unified Receipts.
+A lightweight TypeScript library for extracting selected fields from Apple's ASN.1 encoded Unified Receipts.
 
 > [!IMPORTANT]
 > This library is not a full-fledged receipt parser. 
-> It only extracts some information from Apple's ASN.1 encoded Unified Receipts.
+> It extracts supported fields from Apple's ASN.1 encoded Unified Receipts, including in-app purchase receipts.
 > It does not work with the old-style transaction receipts.
 
 > [!NOTE]
@@ -32,6 +32,9 @@ yarn add @tamtamchik/app-store-receipt-parser
 ```
 
 ## Usage
+
+The result includes selected top-level receipt fields, aggregate in-app transaction IDs,
+and structured in-app receipt data in `IN_APP_RECEIPTS`.
 
 ```typescript
 import { parseReceipt } from '@tamtamchik/app-store-receipt-parser';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tamtamchik/app-store-receipt-parser",
-  "version": "2.2.3",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tamtamchik/app-store-receipt-parser",
-      "version": "2.2.3",
+      "version": "2.3.0",
       "license": "MIT",
       "dependencies": {
         "asn1js": "^3.0.7"

--- a/package-lock.json
+++ b/package-lock.json
@@ -531,9 +531,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2031,9 +2031,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2344,9 +2344,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3212,9 +3212,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tamtamchik/app-store-receipt-parser",
   "version": "2.3.0",
-  "description": "A lightweight TypeScript library for extracting transaction IDs from Apple's ASN.1 encoded receipts.",
+  "description": "A lightweight TypeScript library for extracting selected fields from Apple's ASN.1 encoded receipts.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./src/index.ts",
@@ -20,6 +20,7 @@
     "receipt",
     "parser",
     "ASN.1",
+    "in-app",
     "transaction",
     "typescript"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tamtamchik/app-store-receipt-parser",
-  "version": "2.2.3",
+  "version": "2.3.0",
   "description": "A lightweight TypeScript library for extracting transaction IDs from Apple's ASN.1 encoded receipts.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export type { ParsedReceipt } from './ReceiptParser'
+export type { InAppReceipt, ParsedReceipt } from './ReceiptParser'
 export { parseReceipt } from './ReceiptParser'

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -18,7 +18,7 @@ describe('parseReceipt', () => {
     assert.throws(() => parseReceipt(''), { message: 'Receipt must be a non-empty string.' })
   })
 
-  it('should parse transactions correctly for validReceipt', () => {
+  it('should parse receipt data correctly for validReceipt', () => {
     const receipt = parseReceipt(validReceipt)
 
     assert.ok(receipt)
@@ -73,7 +73,7 @@ describe('parseReceipt', () => {
     })
   })
 
-  it('should parse transactions correctly for validReceipt2', () => {
+  it('should parse receipt data correctly for validReceipt2', () => {
     const receipt = parseReceipt(validReceipt2)
 
     assert.ok(receipt)


### PR DESCRIPTION
## Summary
- Bumps the package version from `2.2.3` to `2.3.0`.
- Adds `CHANGELOG.md` release notes for `2.3.0` and historical entries for all existing tags from `1.0.0` through `2.2.3`.
- Updates package metadata and README wording to describe selected receipt field parsing, including structured in-app purchase receipts.
- Exports the `InAppReceipt` type from the package entrypoint.
- Updates transitive `brace-expansion` resolutions in the lockfile to clear npm audit findings.

## Release scope
- Includes structured `IN_APP_RECEIPTS` parsing for Unified Receipts.
- Keeps the existing top-level in-app fields and transaction ID arrays for backward compatibility.
- Includes the dependency and CI maintenance changes already merged into `main`.

## Version decision
This is currently planned as `2.3.0` because the new receipt data is additive and does not remove or change the existing API. A `3.0.0` release would make more sense if we decide to reposition the package around a broader receipt-parsing API or introduce breaking API cleanup.

## Testing
- `npm_config_cache=/private/tmp/app-store-receipt-parser-npm-cache npm ci`
- `npm_config_cache=/private/tmp/app-store-receipt-parser-npm-cache npm audit`
- `npm test`
- `npm run lint`
- `npm run build`
- `./node_modules/.bin/tsc --noEmit --ignoreDeprecations 6.0 --types node`
- `npm_config_cache=/private/tmp/app-store-receipt-parser-npm-cache npm pack --dry-run`