### PR TITLE
Document last-wins semantics of top-level IN_APP_* fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ console.log(data);
 // }
 ```
 
+> [!WARNING]
+> Top-level scalar `IN_APP_*` fields (e.g. `IN_APP_PRODUCT_ID`, `IN_APP_TRANSACTION_ID`) hold the value
+> from the **last** in-app purchase block encountered in the receipt, and Apple does not guarantee the
+> order of those blocks. They are kept for backward compatibility — for reliable per-purchase data use
+> `IN_APP_RECEIPTS`.
+
 ## Special Thanks
 
 - [@Jurajzovinec](https://github.com/Jurajzovinec) for his superb contribution to the project.


### PR DESCRIPTION
Top-level scalar `IN_APP_*` fields are overwritten by every in-app purchase block during parsing, so they end up holding the value from the last block in the receipt's ASN.1 — and Apple does not guarantee block order. This adds a README warning marking those fields as backward-compatibility only and pointing readers to `IN_APP_RECEIPTS` for reliable per-purchase data.

Docs only, no behavior change.