### PR TITLE
Preserve Environment literal hints and export the type

### DIFF
--- a/src/ReceiptParser.ts
+++ b/src/ReceiptParser.ts
@@ -11,7 +11,7 @@ import {
 
 import { ReceiptVerifier } from './ReceiptVerifier'
 
-export type Environment = 'Production' | 'ProductionSandbox' | string
+export type Environment = 'Production' | 'ProductionSandbox' | (string & {})
 
 export type InAppReceipt = Partial<Record<ReceiptFieldsKeyNames, string>>
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export type { InAppReceipt, ParsedReceipt } from './ReceiptParser'
+export type { Environment, InAppReceipt, ParsedReceipt } from './ReceiptParser'
 export { parseReceipt } from './ReceiptParser'


### PR DESCRIPTION
`'Production' | 'ProductionSandbox' | string` collapses to plain `string`, so the literals gave no IDE autocomplete or narrowing. Using the `(string & {})` idiom keeps the type assignable from any string while preserving the literal hints.

Also re-exports `Environment` from the package entry point so consumers can reference it by name.