### PR TITLE
Decode ASN.1 INTEGER field values to decimal strings

### DIFF
--- a/src/ReceiptParser.ts
+++ b/src/ReceiptParser.ts
@@ -115,6 +115,10 @@ class ReceiptParser {
       return fieldValue.valueBlock.value
     }
 
+    if (fieldValue instanceof ASN1.Integer) {
+      return fieldValue.toBigInt().toString()
+    }
+
     return field.toJSON().valueBlock.valueHex
   }
 

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -35,8 +35,8 @@ describe('parseReceipt', () => {
     assert.deepStrictEqual(receipt.IN_APP_ORIGINAL_PURCHASE_DATE, '2015-08-10T07:12:34Z')
     assert.deepStrictEqual(receipt.IN_APP_EXPIRES_DATE, '2015-08-10T07:19:32Z')
     assert.deepStrictEqual(receipt.IN_APP_CANCELLATION_DATE, '')
-    assert.deepStrictEqual(receipt.IN_APP_QUANTITY, '020101')
-    assert.deepStrictEqual(receipt.IN_APP_WEB_ORDER_LINE_ITEM_ID, '0207038d7ea69472c9')
+    assert.deepStrictEqual(receipt.IN_APP_QUANTITY, '1')
+    assert.deepStrictEqual(receipt.IN_APP_WEB_ORDER_LINE_ITEM_ID, '1000000030274249')
     assert.deepStrictEqual(receipt.IN_APP_PRODUCT_ID, 'monthly')
 
     assert.deepStrictEqual(receipt.IN_APP_TRANSACTION_ID, '1000000166967782')
@@ -63,8 +63,8 @@ describe('parseReceipt', () => {
     assert.deepStrictEqual(receipt.IN_APP_RECEIPTS.at(-1), {
       IN_APP_EXPIRES_DATE: '2015-08-10T07:19:32Z',
       IN_APP_CANCELLATION_DATE: '',
-      IN_APP_QUANTITY: '020101',
-      IN_APP_WEB_ORDER_LINE_ITEM_ID: '0207038d7ea69472c9',
+      IN_APP_QUANTITY: '1',
+      IN_APP_WEB_ORDER_LINE_ITEM_ID: '1000000030274249',
       IN_APP_PRODUCT_ID: 'monthly',
       IN_APP_TRANSACTION_ID: '1000000166967782',
       IN_APP_ORIGINAL_TRANSACTION_ID: '1000000166965150',
@@ -90,8 +90,8 @@ describe('parseReceipt', () => {
     assert.deepStrictEqual(receipt.IN_APP_ORIGINAL_PURCHASE_DATE, '2018-11-13T16:46:31Z')
     assert.deepStrictEqual(receipt.IN_APP_EXPIRES_DATE, '')
     assert.deepStrictEqual(receipt.IN_APP_CANCELLATION_DATE, '')
-    assert.deepStrictEqual(receipt.IN_APP_QUANTITY, '020101')
-    assert.deepStrictEqual(receipt.IN_APP_WEB_ORDER_LINE_ITEM_ID, '020100')
+    assert.deepStrictEqual(receipt.IN_APP_QUANTITY, '1')
+    assert.deepStrictEqual(receipt.IN_APP_WEB_ORDER_LINE_ITEM_ID, '0')
     assert.deepStrictEqual(receipt.IN_APP_PRODUCT_ID, 'test2')
 
     assert.deepStrictEqual(receipt.IN_APP_TRANSACTION_ID, '1000000472106082')
@@ -103,8 +103,8 @@ describe('parseReceipt', () => {
     assert.deepStrictEqual(receipt.IN_APP_RECEIPTS, [{
       IN_APP_EXPIRES_DATE: '',
       IN_APP_CANCELLATION_DATE: '',
-      IN_APP_QUANTITY: '020101',
-      IN_APP_WEB_ORDER_LINE_ITEM_ID: '020100',
+      IN_APP_QUANTITY: '1',
+      IN_APP_WEB_ORDER_LINE_ITEM_ID: '0',
       IN_APP_PRODUCT_ID: 'test2',
       IN_APP_TRANSACTION_ID: '1000000472106082',
       IN_APP_ORIGINAL_TRANSACTION_ID: '1000000472106082',


### PR DESCRIPTION
## Problem

Non-string field values were returned as the hex dump of the whole inner TLV, so `IN_APP_QUANTITY` came back as `'020101'` (the bytes `02 01 01` = INTEGER 1) instead of `'1'`, and `IN_APP_WEB_ORDER_LINE_ITEM_ID` as `'0207038d7ea69472c9'` instead of `'1000000030274249'`.

## Fix

`extractStringValue` now decodes `ASN1.Integer` values via `toBigInt()` (safe for values beyond `Number.MAX_SAFE_INTEGER`) and returns the decimal string. Other non-string types (e.g. `OPAQUE_VALUE`, `SHA1_HASH` raw octets) keep the existing hex representation.

## ⚠️ Breaking change

Consumers relying on the old hex form of `IN_APP_QUANTITY` / `IN_APP_WEB_ORDER_LINE_ITEM_ID` will see different values. The README example also shows the old form — if this lands, it should go out as a major (or clearly flagged minor) release and the README example updated accordingly.