### PR TITLE
chore: simplify dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,25 +4,15 @@ updates:
     directory: /
     schedule:
       interval: weekly
-      day: monday
-      time: "09:00"
-      timezone: Europe/Lisbon
     open-pull-requests-limit: 2
-    versioning-strategy: lockfile-only
     cooldown:
       default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 14
-      semver-patch-days: 7
 
   # Workflows pin actions by full commit SHA; Dependabot updates those pins.
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
-      day: monday
-      time: "09:00"
-      timezone: Europe/Lisbon
     open-pull-requests-limit: 1
     cooldown:
       default-days: 7


### PR DESCRIPTION
Same simplification as [apple-iap-tools#20](https://github.com/tamtamchik/apple-iap-tools/pull/20):

- Dropped explicit `day`/`time`/`timezone` — `weekly` already defaults to Monday.
- Dropped `versioning-strategy: lockfile-only` — as a library we want PRs for new toolchain majors too.
- Collapsed the per-semver `cooldown` tiers into a single `default-days: 7` (the supply-chain protection that matters).
- Kept the `github-actions` section — workflows here pin actions by SHA, Dependabot maintains those pins.

27 lines → 18.