### PR TITLE
Release 2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 2.3.1 - 2026-06-12
+
+### Fixed
+
+- Decoded ASN.1 `INTEGER` field values to decimal strings instead of raw hex.
+- Preserved `Environment` literal type hints and exported the `Environment` type from the package entrypoint.
+- Shipped generated type declarations instead of hand-written ones.
+- Allowed parsing receipts without in-app purchases.
+
+### Changed
+
+- Documented last-wins semantics of top-level `IN_APP_*` fields.
+- Added a warning that receipt signatures are not verified.
+- Updated the README example to decoded integer values.
+
+### Maintenance
+
+- Replaced `tsup` with `tsdown` for the build.
+- Simplified the Dependabot configuration.
+- Updated development dependencies.
+
 ## 2.3.0 - 2026-05-27
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tamtamchik/app-store-receipt-parser",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tamtamchik/app-store-receipt-parser",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "MIT",
       "dependencies": {
         "asn1js": "^3.0.7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tamtamchik/app-store-receipt-parser",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "A lightweight TypeScript library for extracting selected fields from Apple's ASN.1 encoded receipts.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
Bumps the version to 2.3.1 and adds the changelog entry for the fixes accumulated since 2.3.0:

- Decoded ASN.1 `INTEGER` field values to decimal strings (#42)
- Preserved `Environment` literal hints and exported the type (#41)
- Shipped generated type declarations (#39)
- Allowed receipts without in-app purchases (#38)
- Docs and build maintenance (#40, #43, #44, #45)