### PR TITLE
Add Context7 configuration

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -6,8 +6,8 @@
   "excludeFolders": ["src", "test", "dist"],
   "excludeFiles": [],
   "rules": [
-    "The parser does not verify receipt signatures; validate receipts with Apple before trusting them",
-    "ASN.1 INTEGER fields are decoded to decimal strings",
-    "Top-level IN_APP_* fields keep the last in-app purchase value; use IN_APP_RECEIPTS for all purchases"
+    "Validate receipts with Apple before trusting them; the parser does not verify receipt signatures",
+    "Treat parsed INTEGER fields as decimal strings, not numbers",
+    "Use IN_APP_RECEIPTS to access all in-app purchases; top-level IN_APP_* fields only keep the last one"
   ]
 }

--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://context7.com/schema/context7.json",
+  "projectTitle": "App Store Receipt Parser",
+  "description": "A lightweight TypeScript library for extracting selected fields from Apple's ASN.1 encoded receipts.",
+  "folders": [],
+  "excludeFolders": ["src", "test", "dist"],
+  "excludeFiles": [],
+  "rules": [
+    "The parser does not verify receipt signatures; validate receipts with Apple before trusting them",
+    "ASN.1 INTEGER fields are decoded to decimal strings",
+    "Top-level IN_APP_* fields keep the last in-app purchase value; use IN_APP_RECEIPTS for all purchases"
+  ]
+}

--- a/context7.json
+++ b/context7.json
@@ -6,8 +6,12 @@
   "excludeFolders": ["src", "test", "dist"],
   "excludeFiles": [],
   "rules": [
-    "Validate receipts with Apple before trusting them; the parser does not verify receipt signatures",
-    "Treat parsed INTEGER fields as decimal strings, not numbers",
-    "Use IN_APP_RECEIPTS to access all in-app purchases; top-level IN_APP_* fields only keep the last one"
+    "Validate receipts with Apple (App Store Server API) before granting entitlements; the parser does not verify the PKCS#7 signature",
+    "Pass the receipt as a base64 string ('MII...'); old-style transaction receipts are not supported, only unified receipts",
+    "Wrap parseReceipt in try/catch: it throws on empty input, schema mismatch, and missing required fields",
+    "Treat every parsed value as a string: quantities are decimal strings, dates are ISO 8601 strings, absent dates are empty strings",
+    "Use IN_APP_RECEIPTS to access all in-app purchases; top-level IN_APP_* fields only keep the last one",
+    "Use IN_APP_TRANSACTION_IDS and IN_APP_ORIGINAL_TRANSACTION_IDS for deduplicated ID lists across all purchases",
+    "Expect ENVIRONMENT to default to 'Production' when the receipt omits the field"
   ]
 }


### PR DESCRIPTION
Adds a `context7.json` so Context7 indexes the README with the right title, description, and usage rules when the library is submitted to https://context7.com.