### PR TITLE
Add Context7 ownership claim key

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,5 +1,7 @@
 {
   "$schema": "https://context7.com/schema/context7.json",
+  "url": "https://context7.com/tamtamchik/app-store-receipt-parser",
+  "public_key": "pk_QlHk4oryApIHWteupSUUF",
   "projectTitle": "App Store Receipt Parser",
   "description": "A lightweight TypeScript library for extracting selected fields from Apple's ASN.1 encoded receipts.",
   "folders": [],


### PR DESCRIPTION
Adds the `url` and `public_key` fields from the Context7 claim modal to `context7.json` so Context7 can verify repository ownership. The public key is meant to be public — it only proves the repo owner initiated the claim.